### PR TITLE
Importance sample diffuse fix

### DIFF
--- a/data/shadersD3D11/IblImportanceSamplingDiffuse.fx
+++ b/data/shadersD3D11/IblImportanceSamplingDiffuse.fx
@@ -205,6 +205,7 @@ float3 ImportanceSample (float3 N)
         float3 H = importanceSampleDiffuse( Xi, N);
         float3 L = normalize(2 * dot( V, H ) * H - V);
         float NoL = saturate(dot( N, L ));
+        if (NoL > 0.0)
         {
             // Compute Lod using inverse solid angle and pdf.
             // From Chapter 20.4 Mipmap filtered samples in GPU Gems 3.

--- a/data/shadersD3D11/IblImportanceSamplingDiffuse.fx
+++ b/data/shadersD3D11/IblImportanceSamplingDiffuse.fx
@@ -205,7 +205,6 @@ float3 ImportanceSample (float3 N)
         float3 H = importanceSampleDiffuse( Xi, N);
         float3 L = normalize(2 * dot( V, H ) * H - V);
         float NoL = saturate(dot( N, L ));
-        if (NoL > 0.0)
         {
             // Compute Lod using inverse solid angle and pdf.
             // From Chapter 20.4 Mipmap filtered samples in GPU Gems 3.


### PR DESCRIPTION
Minor tweak.

It looks like a line got accidentally deleted and the diffuse importance sampling shader was missing the check for NoL > 0.0.  The saturate call above will clamp any negative values to 0.0, but following along with the implementation defined in Epic Game's Siggraph 2013 course notes, these samples (now at 0.0) should not contribute to the lighting.